### PR TITLE
Make npm package ready

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,7 +1,6 @@
 import React, {useCallback, useRef} from "react";
 import {Animated, Text, View} from "react-native";
 import PropTypes from "prop-types";
-import styled from 'styled-components';
 import {Item, ScrollWrapper, WheelScroller} from "./src/styles/wheel";
 import WheelItems from "./src/WheelItems";
 import {lockOnItem} from "./src/utils/functions";
@@ -27,7 +26,7 @@ const App = (props) => {
     selected = doesIndexExist ? selected : 0;
 
     if (!doesIndexExist) {
-        console.warn("Given index is out of range");
+        console.warn('[Wheelpicker] Given index is out of range');
     }
 
     const scroller = useRef(null);
@@ -77,55 +76,27 @@ const App = (props) => {
     //TODO: Make two covers with border top/bottom instead of one
 
     return (
-        <ExampleContainer>
-            <ScrollWrapper height={height} width={width}>
-                <WheelCover height={height}>
-                    <SelectedOptionCover selectedArea={selectedArea} selectedColor={selectedColor} />
-                </WheelCover>
-                <WheelScroller
-                    decelerationRate={decelerationRate}
-                    as={Animated.ScrollView}
-                    onLayout={() => initialLock(selected * itemHeight)}
-                    ref={scroller}
-                    onScroll={onScroll}
-                    scrollEventThrottle={scrollEventThrottle}
-                    showsVerticalScrollIndicator={false}
-                    onMomentumScrollEnd={onMomentumScrollEnd}
-                >
-                    <WheelItems
-                        itemStyle={selectedItemStyle}
-                        options={options} itemStyles={itemStyles} selectedColor={selectedColor}
-                        animationValue={animatedValueScrollY} itemHeight={itemHeight}
-                        numOfDisplayedItems={numOfDisplayedItems} selectedArea={selectedArea}
-                    />
-                </WheelScroller>
-            </ScrollWrapper>
-        </ExampleContainer>
+        <ScrollWrapper height={height} width={width}>
+            <WheelScroller
+                decelerationRate={decelerationRate}
+                as={Animated.ScrollView}
+                onLayout={() => initialLock(selected * itemHeight)}
+                ref={scroller}
+                onScroll={onScroll}
+                scrollEventThrottle={scrollEventThrottle}
+                showsVerticalScrollIndicator={false}
+                onMomentumScrollEnd={onMomentumScrollEnd}
+            >
+                <WheelItems
+                    itemStyle={selectedItemStyle}
+                    options={options} itemStyles={itemStyles} selectedColor={selectedColor}
+                    animationValue={animatedValueScrollY} itemHeight={itemHeight}
+                    numOfDisplayedItems={numOfDisplayedItems} selectedArea={selectedArea}
+                />
+            </WheelScroller>
+        </ScrollWrapper>
     );
 };
-
-const ExampleContainer = styled.View`
-    flex: 1;
-    align-items: center;
-    justify-content: center;
-`;
-
-const WheelCover = styled.View`
-    position: absolute;
-    width: 100;
-    height: ${props => props.height};
-    align-self: center;
-    align-items: center;
-    justify-content: center;
-`;
-
-const SelectedOptionCover = styled.View`
-    width: 100;
-    height: ${props => props.selectedArea};
-    border-color: ${props => props.selectedColor || 'white'};
-    border-top-width: 1;
-    border-bottom-width: 1;
-`;
 
 App.propTypes = {
     height: PropTypes.number,

--- a/App.js
+++ b/App.js
@@ -1,5 +1,6 @@
 import React, {useCallback, useRef} from "react";
 import {Animated, Text, View} from "react-native";
+import styled from 'styled-components/native';
 import PropTypes from "prop-types";
 import {Item, ScrollWrapper, WheelScroller} from "./src/styles/wheel";
 import WheelItems from "./src/WheelItems";
@@ -77,6 +78,10 @@ const App = (props) => {
 
     return (
         <ScrollWrapper height={height} width={width}>
+            <WheelCover height={height}>
+                <SelectedOptionCover selectedArea={selectedArea} selectedColor={selectedColor} />
+            </WheelCover>
+
             <WheelScroller
                 decelerationRate={decelerationRate}
                 as={Animated.ScrollView}
@@ -134,5 +139,22 @@ App.defaultProps = {
     .fill("")
     .map((_, i) => i + 1)
 };
+
+const WheelCover = styled.View`
+    position: absolute;
+    width: 100;
+    height: ${props => props.height};
+    align-self: center;
+    align-items: center;
+    justify-content: center;
+`;
+
+const SelectedOptionCover = styled.View`
+    width: 100;
+    height: ${props => props.selectedArea};
+    border-color: ${props => props.selectedColor || 'white'};
+    border-top-width: 1;
+    border-bottom-width: 1;
+`;
 
 export default App;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# react-native-wheelpicker
+
+A highly customizable wheel picker for react-native.
+
+
+## Installation
+
+Using npm:
+```bash
+npm i @herolo/react-native-wheelpicker
+```
+
+Using yarn:
+```bash
+yarn add @herolo/react-native-wheelpicker
+```
+
+
+## Usage
+
+```react
+import WheelPicker from '@herolo/rn-wheelpicker';
+
+export const Home = (props) => {
+  return (
+    <View>
+      <WheelPicker
+        height={100} 
+        width={100}
+        options={['David', 'Sarah', 'Daniel', 'Michelle']}
+        selectedColor="lightblue"
+      />
+
+    </View>
+  );
+};
+```
+
+## Props
+
+| Prop name           | Description                                                                                                | Type                | Default                          |
+|---------------------|------------------------------------------------------------------------------------------------------------|---------------------|----------------------------------|
+| height              | The height of the wheelpicker                                                                              | number              | 200                              |
+| width               | The width of the wheelpicker                                                                               | number              | 80                               |
+| numOfDisplayedItems | Determines how many items appear                                                                           | number              | 5                                |
+| decelerationRate    | Determines the deceleration rate of the ScrollView element containing the options                          | number              | 0.95                             |
+| scrollEventThrottle | Determines the scroll event throttle rate of the FlatList                                                  | number              | 16                               |
+| itemStyles          | Styles of items in the wheel picker                                                                        | Style object        | {}                               |
+| borderWidth         | Border with of the selected item                                                                           | number              | 0                                |
+| selected            | The index of the selected item. This was chosen over the value, due to the possibility of duplicate values | number              | 0                                |
+| selectedColor       | Font color of the selected item                                                                            | string              | red                              |
+| selectedItemStyle   | Style of the selected item box                                                                             | Style object        | {}                               |
+| onSelect            | A function that takes the value as a parameter                                                             | (value: any) => any | ()=>{}                           |
+| borderColor         | Color of the border of the selected item                                                                   | string              | yellow                           |
+| options             | An array of the options to be displayed and chosen from                                                    | Array<any>          | ['Daniel', 'Moses', 1, 2, 3, 42] |
+
+## Contributing
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+Please make sure to update tests as appropriate.
+
+## License
+[MIT](https://choosealicense.com/licenses/mit/)

--- a/index.js
+++ b/index.js
@@ -1,9 +1,3 @@
-/**
- * @format
- */
+import WheelPicker from './App';
 
-import {AppRegistry} from 'react-native';
-import App from './App';
-import {name as appName} from './app.json';
-
-AppRegistry.registerComponent(appName, () => App);
+export default WheelPicker;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "peerDependencies": {
     "react": "16.8.3",
-    "react-native": "0.59.9",
+    "react-native": "0.59.9"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,18 @@
 {
-  "name": "wheel",
+  "name": "@herolo/rn-wheelpicker",
   "version": "0.0.1",
-  "private": true,
+  "private": false,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest"
   },
   "dependencies": {
     "prop-types": "^15.7.2",
+    "styled-components": "^4.3.1"
+  },
+  "peerDependencies": {
     "react": "16.8.3",
     "react-native": "0.59.9",
-    "styled-components": "^4.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@herolo/rn-wheelpicker",
+  "name": "@herolo/rn-wheelpicker-test",
   "version": "0.0.1",
   "private": false,
   "scripts": {


### PR DESCRIPTION
Add README.md with props, explanations and lisences.

Still missing there: example animations, versioning.

Make it importable (so `react-native run-android` won't work anymore, can only import from example project and run there).

Move react and react native to peerDependencies.

Was tested with `npm pack`.